### PR TITLE
修复坏链检测失效

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,7 +12,7 @@ jobs:
     
       - uses: filiph/linkcheck@3.0.0
         with:
-          arguments: -e https://yftdtddh.github.io/muxizyhz/ > report.txt
+          arguments: -e https://yftdtddh.github.io/ > report.txt
       
       - uses: actions/upload-artifact@v4.0.0
         if: always()


### PR DESCRIPTION
由于网址更换，原有的坏链检测失效，需要修改[check-links.yml](https://github.com/yftdtddh/yftdtddh.github.io/commit/17f3e11b8c441ffa3e560bec0748a6e7bc04c08a)中的链接